### PR TITLE
Integrate local Ollama server support

### DIFF
--- a/camel/model_backend.py
+++ b/camel/model_backend.py
@@ -30,9 +30,13 @@ except ImportError:
 
 import os
 
-OPENAI_API_KEY = os.environ['OPENAI_API_KEY']
-if 'BASE_URL' in os.environ:
-    BASE_URL = os.environ['BASE_URL']
+OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
+if "OPENAI_API_BASE" in os.environ:
+    BASE_URL = os.environ["OPENAI_API_BASE"]
+elif "OPENAI_BASE_URL" in os.environ:
+    BASE_URL = os.environ["OPENAI_BASE_URL"]
+elif "BASE_URL" in os.environ:
+    BASE_URL = os.environ["BASE_URL"]
 else:
     BASE_URL = None
 
@@ -78,9 +82,7 @@ class OpenAIModel(ModelBackend):
                     base_url=BASE_URL,
                 )
             else:
-                client = openai.OpenAI(
-                    api_key=OPENAI_API_KEY
-                )
+                client = openai.OpenAI(api_key=OPENAI_API_KEY)
 
             num_max_token_map = {
                 "gpt-3.5-turbo": 4096,
@@ -91,26 +93,31 @@ class OpenAIModel(ModelBackend):
                 "gpt-4-0613": 8192,
                 "gpt-4-32k": 32768,
                 "gpt-4-turbo": 100000,
-                "gpt-4o": 4096, #100000
-                "gpt-4o-mini": 16384, #100000
+                "gpt-4o": 4096,  # 100000
+                "gpt-4o-mini": 16384,  # 100000
             }
             num_max_token = num_max_token_map[self.model_type.value]
             num_max_completion_tokens = num_max_token - num_prompt_tokens
-            self.model_config_dict['max_tokens'] = num_max_completion_tokens
+            self.model_config_dict["max_tokens"] = num_max_completion_tokens
 
-            response = client.chat.completions.create(*args, **kwargs, model=self.model_type.value,
-                                                      **self.model_config_dict)
+            response = client.chat.completions.create(
+                *args, **kwargs, model=self.model_type.value, **self.model_config_dict
+            )
 
             cost = prompt_cost(
                 self.model_type.value,
                 num_prompt_tokens=response.usage.prompt_tokens,
-                num_completion_tokens=response.usage.completion_tokens
+                num_completion_tokens=response.usage.completion_tokens,
             )
 
             log_visualize(
                 "**[OpenAI_Usage_Info Receive]**\nprompt_tokens: {}\ncompletion_tokens: {}\ntotal_tokens: {}\ncost: ${:.6f}\n".format(
-                    response.usage.prompt_tokens, response.usage.completion_tokens,
-                    response.usage.total_tokens, cost))
+                    response.usage.prompt_tokens,
+                    response.usage.completion_tokens,
+                    response.usage.total_tokens,
+                    cost,
+                )
+            )
             if not isinstance(response, ChatCompletion):
                 raise RuntimeError("Unexpected return from OpenAI API")
             return response
@@ -124,26 +131,31 @@ class OpenAIModel(ModelBackend):
                 "gpt-4-0613": 8192,
                 "gpt-4-32k": 32768,
                 "gpt-4-turbo": 100000,
-                "gpt-4o": 4096, #100000
-                "gpt-4o-mini": 16384, #100000
+                "gpt-4o": 4096,  # 100000
+                "gpt-4o-mini": 16384,  # 100000
             }
             num_max_token = num_max_token_map[self.model_type.value]
             num_max_completion_tokens = num_max_token - num_prompt_tokens
-            self.model_config_dict['max_tokens'] = num_max_completion_tokens
+            self.model_config_dict["max_tokens"] = num_max_completion_tokens
 
-            response = openai.ChatCompletion.create(*args, **kwargs, model=self.model_type.value,
-                                                    **self.model_config_dict)
+            response = openai.ChatCompletion.create(
+                *args, **kwargs, model=self.model_type.value, **self.model_config_dict
+            )
 
             cost = prompt_cost(
                 self.model_type.value,
                 num_prompt_tokens=response["usage"]["prompt_tokens"],
-                num_completion_tokens=response["usage"]["completion_tokens"]
+                num_completion_tokens=response["usage"]["completion_tokens"],
             )
 
             log_visualize(
                 "**[OpenAI_Usage_Info Receive]**\nprompt_tokens: {}\ncompletion_tokens: {}\ntotal_tokens: {}\ncost: ${:.6f}\n".format(
-                    response["usage"]["prompt_tokens"], response["usage"]["completion_tokens"],
-                    response["usage"]["total_tokens"], cost))
+                    response["usage"]["prompt_tokens"],
+                    response["usage"]["completion_tokens"],
+                    response["usage"]["total_tokens"],
+                    cost,
+                )
+            )
             if not isinstance(response, Dict):
                 raise RuntimeError("Unexpected return from OpenAI API")
             return response
@@ -162,8 +174,10 @@ class StubModel(ModelBackend):
             id="stub_model_id",
             usage=dict(),
             choices=[
-                dict(finish_reason="stop",
-                     message=dict(content=ARBITRARY_STRING, role="assistant"))
+                dict(
+                    finish_reason="stop",
+                    message=dict(content=ARBITRARY_STRING, role="assistant"),
+                )
             ],
         )
 
@@ -188,7 +202,7 @@ class ModelFactory:
             ModelType.GPT_4_TURBO_V,
             ModelType.GPT_4O,
             ModelType.GPT_4O_MINI,
-            None
+            None,
         }:
             model_class = OpenAIModel
         elif model_type == ModelType.STUB:

--- a/camel/web_spider.py
+++ b/camel/web_spider.py
@@ -6,8 +6,12 @@ import wikipediaapi
 import os
 import time
 
-self_api_key = os.environ.get('OPENAI_API_KEY')
-BASE_URL = os.environ.get('BASE_URL')
+self_api_key = os.environ.get("OPENAI_API_KEY")
+BASE_URL = (
+    os.environ.get("OPENAI_API_BASE")
+    or os.environ.get("OPENAI_BASE_URL")
+    or os.environ.get("BASE_URL")
+)
 
 if BASE_URL:
     client = openai.OpenAI(
@@ -15,21 +19,20 @@ if BASE_URL:
         base_url=BASE_URL,
     )
 else:
-    client = openai.OpenAI(
-        api_key=self_api_key
-    )
+    client = openai.OpenAI(api_key=self_api_key)
+
 
 def get_baidu_baike_content(keyword):
     # design api by the baidubaike
-    url = f'https://baike.baidu.com/item/{keyword}'
+    url = f"https://baike.baidu.com/item/{keyword}"
     # post request
     response = requests.get(url)
 
     # Beautiful Soup part for the html content
-    soup = BeautifulSoup(response.content, 'html.parser')
+    soup = BeautifulSoup(response.content, "html.parser")
     # find the main content in the page
     # main_content = soup.find('div', class_='lemma-summary')
-    main_content = soup.contents[-1].contents[0].contents[4].attrs['content']
+    main_content = soup.contents[-1].contents[0].contents[4].attrs["content"]
     # find the target content
     # content_text = main_content.get_text().strip()
     return main_content
@@ -37,8 +40,8 @@ def get_baidu_baike_content(keyword):
 
 def get_wiki_content(keyword):
     #  Wikipedia API ready
-    wiki_wiki = wikipediaapi.Wikipedia('MyProjectName (merlin@example.com)', 'en')
-    #the topic content which you want to spider
+    wiki_wiki = wikipediaapi.Wikipedia("MyProjectName (merlin@example.com)", "en")
+    # the topic content which you want to spider
     search_topic = keyword
     # get the page content
     page_py = wiki_wiki.page(search_topic)
@@ -51,39 +54,48 @@ def get_wiki_content(keyword):
     return page_py.summary
 
 
-
 def modal_trans(task_dsp):
     try:
-        task_in ="'" + task_dsp + \
-               "'Just give me the most important keyword about this sentence without explaining it and your answer should be only one keyword."
+        task_in = (
+            "'"
+            + task_dsp
+            + "'Just give me the most important keyword about this sentence without explaining it and your answer should be only one keyword."
+        )
         messages = [{"role": "user", "content": task_in}]
-        response = client.chat.completions.create(messages=messages,
-        model="gpt-3.5-turbo-16k",
-        temperature=0.2,
-        top_p=1.0,
-        n=1,
-        stream=False,
-        frequency_penalty=0.0,
-        presence_penalty=0.0,
-        logit_bias={})
+        response = client.chat.completions.create(
+            messages=messages,
+            model="gpt-3.5-turbo-16k",
+            temperature=0.2,
+            top_p=1.0,
+            n=1,
+            stream=False,
+            frequency_penalty=0.0,
+            presence_penalty=0.0,
+            logit_bias={},
+        )
         response_text = response.choices[0].message.content
         spider_content = get_wiki_content(response_text)
         # time.sleep(1)
-        task_in = "'" + spider_content + \
-               "',Summarize this paragraph and return the key information."
+        task_in = (
+            "'"
+            + spider_content
+            + "',Summarize this paragraph and return the key information."
+        )
         messages = [{"role": "user", "content": task_in}]
-        response = client.chat.completions.create(messages=messages,
-        model="gpt-3.5-turbo-16k",
-        temperature=0.2,
-        top_p=1.0,
-        n=1,
-        stream=False,
-        frequency_penalty=0.0,
-        presence_penalty=0.0,
-        logit_bias={})
+        response = client.chat.completions.create(
+            messages=messages,
+            model="gpt-3.5-turbo-16k",
+            temperature=0.2,
+            top_p=1.0,
+            n=1,
+            stream=False,
+            frequency_penalty=0.0,
+            presence_penalty=0.0,
+            logit_bias={},
+        )
         result = response.choices[0].message.content
         print("web spider content:", result)
     except:
-        result = ''
+        result = ""
         print("the content is none")
     return result

--- a/ecl/embedding.py
+++ b/ecl/embedding.py
@@ -1,21 +1,23 @@
 import os
 import openai
 from openai import OpenAI
-OPENAI_API_KEY = os.environ['OPENAI_API_KEY']
-if 'BASE_URL' in os.environ:
-    BASE_URL = os.environ['BASE_URL']
+
+OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
+if "OPENAI_API_BASE" in os.environ:
+    BASE_URL = os.environ["OPENAI_API_BASE"]
+elif "OPENAI_BASE_URL" in os.environ:
+    BASE_URL = os.environ["OPENAI_BASE_URL"]
+elif "BASE_URL" in os.environ:
+    BASE_URL = os.environ["BASE_URL"]
 else:
     BASE_URL = None
 import sys
 import time
-from tenacity import (
-    retry,
-    stop_after_attempt,
-    wait_random_exponential,
-    wait_fixed
-)
+from tenacity import retry, stop_after_attempt, wait_random_exponential, wait_fixed
 from utils import log_and_print_online
-sys.path.append(os.path.join(os.getcwd(),"ecl"))
+
+sys.path.append(os.path.join(os.getcwd(), "ecl"))
+
 
 class OpenAIEmbedding:
     def __init__(self, **params):
@@ -28,57 +30,63 @@ class OpenAIEmbedding:
         self.total_tokens = 0
 
     @retry(wait=wait_random_exponential(min=2, max=5), stop=stop_after_attempt(10))
-    def get_text_embedding(self,text: str):
-            if BASE_URL:
-                client = openai.OpenAI(
-                    api_key=OPENAI_API_KEY,
-                    base_url=BASE_URL,
-                )
-            else:
-                client = openai.OpenAI(
-                    api_key=OPENAI_API_KEY
-                )
+    def get_text_embedding(self, text: str):
+        if BASE_URL:
+            client = openai.OpenAI(
+                api_key=OPENAI_API_KEY,
+                base_url=BASE_URL,
+            )
+        else:
+            client = openai.OpenAI(api_key=OPENAI_API_KEY)
 
-            if len(text)>8191:
-                  text = text[:8190]
-            response = client.embeddings.create(input = text, model="text-embedding-ada-002").model_dump()
-            embedding = response['data'][0]['embedding']
-            log_and_print_online(
+        if len(text) > 8191:
+            text = text[:8190]
+        response = client.embeddings.create(
+            input=text, model="text-embedding-ada-002"
+        ).model_dump()
+        embedding = response["data"][0]["embedding"]
+        log_and_print_online(
             "Get text embedding from {}:\n**[OpenAI_Usage_Info Receive]**\nprompt_tokens: {}\ntotal_tokens: {}\n".format(
-                response["model"],response["usage"]["prompt_tokens"],response["usage"]["total_tokens"]))
-            self.text_prompt_tokens += response["usage"]["prompt_tokens"]
-            self.text_total_tokens += response["usage"]["total_tokens"]
-            self.prompt_tokens += response["usage"]["prompt_tokens"]
-            self.total_tokens += response["usage"]["total_tokens"]
+                response["model"],
+                response["usage"]["prompt_tokens"],
+                response["usage"]["total_tokens"],
+            )
+        )
+        self.text_prompt_tokens += response["usage"]["prompt_tokens"]
+        self.text_total_tokens += response["usage"]["total_tokens"]
+        self.prompt_tokens += response["usage"]["prompt_tokens"]
+        self.total_tokens += response["usage"]["total_tokens"]
 
-            return embedding
+        return embedding
 
     @retry(wait=wait_random_exponential(min=10, max=60), stop=stop_after_attempt(10))
-    def get_code_embedding(self,code: str):
-            if BASE_URL:
-                client = openai.OpenAI(
-                    api_key=OPENAI_API_KEY,
-                    base_url=BASE_URL,
-                )
-            else:
-                client = openai.OpenAI(
-                    api_key=OPENAI_API_KEY
-                )
-            if len(code) == 0:
-                  code = "#"
-            elif len(code) >8191:
-                  code = code[0:8190]
-            response = client.embeddings.create(input=code, model="text-embedding-ada-002").model_dump()
-            embedding = response['data'][0]['embedding']
-            log_and_print_online(
+    def get_code_embedding(self, code: str):
+        if BASE_URL:
+            client = openai.OpenAI(
+                api_key=OPENAI_API_KEY,
+                base_url=BASE_URL,
+            )
+        else:
+            client = openai.OpenAI(api_key=OPENAI_API_KEY)
+        if len(code) == 0:
+            code = "#"
+        elif len(code) > 8191:
+            code = code[0:8190]
+        response = client.embeddings.create(
+            input=code, model="text-embedding-ada-002"
+        ).model_dump()
+        embedding = response["data"][0]["embedding"]
+        log_and_print_online(
             "Get code embedding from {}:\n**[OpenAI_Usage_Info Receive]**\nprompt_tokens: {}\ntotal_tokens: {}\n".format(
-                response["model"],response["usage"]["prompt_tokens"],response["usage"]["total_tokens"]))
-            
-            self.code_prompt_tokens += response["usage"]["prompt_tokens"]
-            self.code_total_tokens += response["usage"]["total_tokens"]
-            self.prompt_tokens += response["usage"]["prompt_tokens"]
-            self.total_tokens += response["usage"]["total_tokens"]
+                response["model"],
+                response["usage"]["prompt_tokens"],
+                response["usage"]["total_tokens"],
+            )
+        )
 
-            return embedding
+        self.code_prompt_tokens += response["usage"]["prompt_tokens"]
+        self.code_total_tokens += response["usage"]["total_tokens"]
+        self.prompt_tokens += response["usage"]["prompt_tokens"]
+        self.total_tokens += response["usage"]["total_tokens"]
 
-
+        return embedding

--- a/ecl/utils.py
+++ b/ecl/utils.py
@@ -11,16 +11,18 @@ import os
 from abc import ABC, abstractmethod
 import tiktoken
 from typing import Any, Dict
-from tenacity import (
-    retry,
-    stop_after_attempt,
-    wait_exponential
-)
-OPENAI_API_KEY = os.environ['OPENAI_API_KEY']
-if 'BASE_URL' in os.environ:
-    BASE_URL = os.environ['BASE_URL']
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
+if "OPENAI_API_BASE" in os.environ:
+    BASE_URL = os.environ["OPENAI_API_BASE"]
+elif "OPENAI_BASE_URL" in os.environ:
+    BASE_URL = os.environ["OPENAI_BASE_URL"]
+elif "BASE_URL" in os.environ:
+    BASE_URL = os.environ["BASE_URL"]
 else:
     BASE_URL = None
+
 
 def getFilesFromType(sourceDir, filetype):
     files = []
@@ -30,20 +32,22 @@ def getFilesFromType(sourceDir, filetype):
                 files.append(os.path.join(root, filename))
     return files
 
+
 def cmd(command: str):
     print(">> {}".format(command))
     text = subprocess.run(command, shell=True, text=True, stdout=subprocess.PIPE).stdout
     return text
 
+
 def get_easyDict_from_filepath(path: str):
     # print(path)
-    if path.endswith('.json'):
-        with open(path, 'r', encoding="utf-8") as file:
+    if path.endswith(".json"):
+        with open(path, "r", encoding="utf-8") as file:
             config_map = json.load(file, strict=False)
             config_easydict = EasyDict(config_map)
             return config_easydict
-    if path.endswith('.yaml'):
-        file_data = open(path, 'r', encoding="utf-8").read()
+    if path.endswith(".yaml"):
+        file_data = open(path, "r", encoding="utf-8").read()
         config_map = yaml.load(file_data, Loader=yaml.FullLoader)
         config_easydict = EasyDict(config_map)
         return config_easydict
@@ -65,8 +69,8 @@ def calc_max_token(messages, model):
         "gpt-4": 8192,
         "gpt-4-0613": 8192,
         "gpt-4-32k": 32768,
-        "gpt-4o": 4096, #100000
-        "gpt-4o-mini": 16384, #100000
+        "gpt-4o": 4096,  # 100000
+        "gpt-4o-mini": 16384,  # 100000
     }
     num_max_token = num_max_token_map[model]
     num_max_completion_tokens = num_max_token - num_prompt_tokens
@@ -90,37 +94,37 @@ class ModelBackend(ABC):
         """
         pass
 
+
 class OpenAIModel(ModelBackend):
     r"""OpenAI API in a unified ModelBackend interface."""
 
-    def __init__(self, model_type, model_config_dict: Dict=None) -> None:
+    def __init__(self, model_type, model_config_dict: Dict = None) -> None:
         super().__init__()
         self.model_type = model_type
         self.model_config_dict = model_config_dict
         if self.model_config_dict == None:
-            self.model_config_dict = {"temperature": 0.2,
-                                "top_p": 1.0,
-                                "n": 1,
-                                "stream": False,
-                                "frequency_penalty": 0.0,
-                                "presence_penalty": 0.0,
-                                "logit_bias": {},
-                                }
+            self.model_config_dict = {
+                "temperature": 0.2,
+                "top_p": 1.0,
+                "n": 1,
+                "stream": False,
+                "frequency_penalty": 0.0,
+                "presence_penalty": 0.0,
+                "logit_bias": {},
+            }
         self.prompt_tokens = 0
         self.completion_tokens = 0
         self.total_tokens = 0
 
     @retry(wait=wait_exponential(min=5, max=60), stop=stop_after_attempt(5))
-    def run(self, messages) :
+    def run(self, messages):
         if BASE_URL:
             client = openai.OpenAI(
                 api_key=OPENAI_API_KEY,
                 base_url=BASE_URL,
             )
         else:
-            client = openai.OpenAI(
-                api_key=OPENAI_API_KEY
-            )
+            client = openai.OpenAI(api_key=OPENAI_API_KEY)
         current_retry = 0
         max_retry = 5
 
@@ -138,43 +142,46 @@ class OpenAIModel(ModelBackend):
             "gpt-4": 8192,
             "gpt-4-0613": 8192,
             "gpt-4-32k": 32768,
-            "gpt-4o": 4096, #100000
-            "gpt-4o-mini": 16384, #100000
+            "gpt-4o": 4096,  # 100000
+            "gpt-4o-mini": 16384,  # 100000
         }
-        response = client.chat.completions.create(messages = messages,
-        model = "gpt-3.5-turbo-16k",
-        temperature = 0.2,
-        top_p = 1.0,
-        n = 1,
-        stream = False,
-        frequency_penalty = 0.0,
-        presence_penalty = 0.0,
-        logit_bias = {},
+        response = client.chat.completions.create(
+            messages=messages,
+            model="gpt-3.5-turbo-16k",
+            temperature=0.2,
+            top_p=1.0,
+            n=1,
+            stream=False,
+            frequency_penalty=0.0,
+            presence_penalty=0.0,
+            logit_bias={},
         ).model_dump()
-        response_text = response['choices'][0]['message']['content']
-
-
+        response_text = response["choices"][0]["message"]["content"]
 
         num_max_token = num_max_token_map[self.model_type]
         num_max_completion_tokens = num_max_token - num_prompt_tokens
-        self.model_config_dict['max_tokens'] = num_max_completion_tokens
+        self.model_config_dict["max_tokens"] = num_max_completion_tokens
         log_and_print_online(
             "InstructionStar generation:\n**[OpenAI_Usage_Info Receive]**\nprompt_tokens: {}\ncompletion_tokens: {}\ntotal_tokens: {}\n".format(
-                response["usage"]["prompt_tokens"], response["usage"]["completion_tokens"],
-                response["usage"]["total_tokens"]))
+                response["usage"]["prompt_tokens"],
+                response["usage"]["completion_tokens"],
+                response["usage"]["total_tokens"],
+            )
+        )
         self.prompt_tokens += response["usage"]["prompt_tokens"]
         self.completion_tokens += response["usage"]["completion_tokens"]
         self.total_tokens += response["usage"]["total_tokens"]
-        
+
         if not isinstance(response, Dict):
             raise RuntimeError("Unexpected return from OpenAI API")
         return response
 
-    
+
 def now():
     return time.strftime("%Y%m%d%H%M%S", time.localtime())
 
+
 def log_and_print_online(content=None):
-    if  content is not None:
+    if content is not None:
         print(content)
         logging.info(content)

--- a/tests/test_ollama_integration.py
+++ b/tests/test_ollama_integration.py
@@ -1,0 +1,17 @@
+import os
+import requests
+
+
+def test_ollama_chat():
+    base_url = os.getenv("OPENAI_API_BASE", "http://localhost:11434/v1")
+    model = os.getenv("OLLAMA_MODEL", "llama3")
+    data = {
+        "model": model,
+        "messages": [{"role": "user", "content": "Hello, world!"}],
+        "stream": False,
+    }
+    resp = requests.post(f"{base_url}/chat/completions", json=data, timeout=5)
+    resp.raise_for_status()
+    js = resp.json()
+    assert "choices" in js
+    assert "message" in js["choices"][0]

--- a/wiki.md
+++ b/wiki.md
@@ -450,3 +450,26 @@ Detailed descriptions and experiment results about this Experiential Co-Evolving
     If you add and commit the software log file under the software folder, there will be no ``Changes not staged for commit:``
   - Some phase executions may not change the code, and thereby there is no commit. For example, the software is tested without problems and there is no modification, so the test phase would leave no commit.
   
+## Integracja lokalnych modeli
+ChatDev obs\u0142uguje serwery zgodne z API OpenAI. Aby skorzysta\u0107 z lokalnego serwera Ollama ustaw zmienn\u0105 \u015brodowiskow\u0105 `OPENAI_API_BASE` wskazuj\u0105c\u0105 na adres np. `http://localhost:11434/v1`.
+
+```bash
+export OPENAI_API_BASE="http://localhost:11434/v1"
+export OPENAI_API_KEY="none"  # je\u015bli serwer nie wymaga klucza
+```
+
+Nast\u0119pnie ca\u0142y kod korzystaj\u0105cy z biblioteki OpenAI automatycznie skieruje zapytania na lokalny serwer. Przyk\u0142adowe zapytanie:
+
+```python
+import os
+import openai
+
+client = openai.OpenAI(base_url=os.getenv("OPENAI_API_BASE"), api_key=os.getenv("OPENAI_API_KEY"))
+resp = client.chat.completions.create(
+    model="llama3",
+    messages=[{"role": "user", "content": "Hello, world!"}]
+)
+print(resp.choices[0].message.content)
+```
+
+


### PR DESCRIPTION
## Summary
- allow `OPENAI_API_BASE` or `OPENAI_BASE_URL` to override API endpoints
- add Ollama integration section in wiki
- provide simple end-to-end test against local Ollama

## Testing
- `pip install openai==1.47.1`
- `pip install black==24.4.0`
- `pip install requests`
- `pytest -q` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_6856a0147d2083339af347627e2eb4b9